### PR TITLE
Fix compilation with gcc 10

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -36,6 +36,8 @@ struct {
   uint32_t iter;
 } hash_store;
 
+shared_z_keys_t shared_z_keys;
+
 uint64_t rand64()
 {
   int i;

--- a/src/hash.h
+++ b/src/hash.h
@@ -35,11 +35,11 @@ enum {
   Z_KEYS_MAX_INDEX,
 };
 
-struct {
+typedef struct {
   uint64_t positions[SQ_LIMIT][Z_KEYS_MAX_INDEX];
   uint64_t c_flags[C_FLAG_MAX];
   uint64_t side_flag;
-} shared_z_keys;
+} shared_z_keys_t;
 
 typedef union {
   struct {
@@ -51,6 +51,8 @@ typedef union {
   uint64_t raw;
 } hash_data_t;
 _Static_assert(sizeof(hash_data_t) == 8, "hash_data_t size error");
+
+extern shared_z_keys_t shared_z_keys;
 
 int adjust_hash_score(int, int);
 hash_data_t get_hash_data(search_data_t *);

--- a/src/search.c
+++ b/src/search.c
@@ -52,6 +52,9 @@
 #define _see_captures_margin(depth)   (-100 * (depth))
 #define _h_score(depth)               (_sqr(_min(depth, 16)) * 32)
 
+search_settings_t search_settings;
+search_status_t search_status;
+
 const int lmp[][LMP_DEPTH + 1] = {
   { 0, 2, 3, 5, 9, 13, 18, 25, 34, 45, 55 },
   { 0, 5, 6, 9, 14, 21, 30, 41, 55, 69, 84 }

--- a/src/search.h
+++ b/src/search.h
@@ -40,19 +40,22 @@ typedef struct {
   uint64_t hash_keys[MAX_GAME_PLY];
 } search_data_t;
 
-struct {
+typedef struct {
   int max_depth, done, search_finished, score, depth, tm_steps;
   uint64_t time_in_ms, max_time, target_time[TM_STEPS];
   struct {
     int infinite, ponder, time, inc, movestogo, depth, movetime;
   } go;
-} search_status;
+} search_status_t;
 
-struct {
+typedef struct {
   int max_threads, ponder_mode, tb_probe_depth;
   search_data_t *sd, *threads_search_data;
   pthread_mutex_t mutex;
-} search_settings;
+} search_settings_t;
+
+extern search_settings_t search_settings;
+extern search_status_t search_status;
 
 void init_lmr();
 void reset_search_data(search_data_t *);


### PR DESCRIPTION
Build with gcc 10.2.1 fails with warnings like:

/usr/bin/ld: /tmp/cchxFSX2.o (symbol from plugin): in function `set_killer_move':
(.text+0x0): multiple definition of `search_settings'; /tmp/ccajauf3.o (symbol from plugin):(.text+0x0): first defined here

(All reported symbols: eval_material_moves, init_lmr, init_move_list, main,
search_settings, set_pins_and_checks, shared_z_keys, test_checks_and_material_moves)

This is because there are some structures defined in .h (search.h and hash.h)
and they end up defined multiple times in the objects, linker does not like it.
This does not happen with gcc 9, but I haven't investigated why.

Fix that by splitting declaration and definition of search_settings,
search_status and shared_z_keys.